### PR TITLE
Display:MSM8916 : Missing header Files Fix:Build errors

### DIFF
--- a/libcopybit/software_converter.cpp
+++ b/libcopybit/software_converter.cpp
@@ -31,6 +31,7 @@
 #include <stdlib.h>
 #include <errno.h>
 #include "software_converter.h"
+#include <cstring>
 
 /** Convert YV12 to YCrCb_420_SP */
 int convertYV12toYCrCb420SP(const copybit_image_t *src, private_handle_t *yv12_handle)


### PR DESCRIPTION
hardware/qcom/display-caf/msm8916/libcopybit/software_converter.cpp:61:5:
error: use of undeclared identifier 'memcpy'
    memcpy((char *)yv12_handle->base,(char
*)hnd->base,y_size);
    ^
hardware/qcom/display-caf/msm8916/libcopybit/software_converter.cpp:155:9:
error: use of undeclared identifier 'memcpy'
        memcpy(dst, src, width);
        ^
hardware/qcom/display-caf/msm8916/libcopybit/software_converter.cpp:166:9:
error: use of undeclared identifier 'memcpy'
        memcpy(dst, src, info.src_stride);